### PR TITLE
Allow passing of limit parameter to opendatafrance

### DIFF
--- a/lib/geocoder/opendatafrancegeocoder.js
+++ b/lib/geocoder/opendatafrancegeocoder.js
@@ -45,8 +45,10 @@ OpendataFranceGeocoder.prototype._geocode = function(value, callback) {
       if (value.citycode) {
         params.citycode = value.citycode;
       }
+      if (value.limit) {
+        params.limit = value.limit;
+      }
     }
-    this._forceParams(params);
 
     this.httpAdapter.get(this._endpoint, params, function(err, result) {
         if (err) {
@@ -131,7 +133,6 @@ OpendataFranceGeocoder.prototype._reverse = function(query, callback) {
       var v = query[k];
       params[k] = v;
     }
-    this._forceParams(params);
 
     this.httpAdapter.get(this._endpoint_reverse , params, function(err, result) {
         if (err) {
@@ -176,10 +177,6 @@ OpendataFranceGeocoder.prototype._getCommonParams = function(){
     }
 
     return params;
-};
-
-OpendataFranceGeocoder.prototype._forceParams = function(params){
-  params.limit = 20;
 };
 
 module.exports = OpendataFranceGeocoder;


### PR DESCRIPTION
Currently the OpenDataFrance always requests 20 records at a time via `limit`. Turns out we don't need to set a limit at all - the API defaults to 5 without the parameter being set - and with this addition we can pass our own custom limit in.